### PR TITLE
docs: update README badge link to docs/index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <div align="center">
 
-[![DEMO](https://img.shields.io/badge/🚀_DEMO-GREENEDUMAP-green?style=for-the-badge&logo=rocket&logoColor=white&labelColor=4a5568&color=22c55e)](https://github.com/MNM-DTU-DZ2/GreenEduMap-DTUDZ) [![DOCS](https://img.shields.io/badge/📚_DOCS-GREENEDUMAP-blue?style=for-the-badge&logo=book&logoColor=white&labelColor=4a5568&color=3b82f6)](https://MNM-DTU-DZ2.github.io/GreenEduMap-DTUDZ/)
+[![DEMO](https://img.shields.io/badge/🚀_DEMO-GREENEDUMAP-green?style=for-the-badge&logo=rocket&logoColor=white&labelColor=4a5568&color=22c55e)](https://github.com/MNM-DTU-DZ2/GreenEduMap-DTUDZ) [![DOCS](https://img.shields.io/badge/📚_DOCS-GREENEDUMAP-blue?style=for-the-badge&logo=book&logoColor=white&labelColor=4a5568&color=3b82f6)](docs/index.md)
 
 </div>
 


### PR DESCRIPTION
Updates the documentation badge link in README.md to point to the local docs/index.md file instead of the external URL.